### PR TITLE
remove axis cycler from matplotlibrc

### DIFF
--- a/{{cookiecutter.project_short_name}}/matplotlibrc
+++ b/{{cookiecutter.project_short_name}}/matplotlibrc
@@ -1,7 +1,6 @@
 font.family: sans-serif
 font.sans-serif: Ubuntu
 image.cmap: viridis
-axes.prop_cycle : tab20
 axes.grid : false
 legend.frameon : false
 savefig.bbox : tight


### PR DESCRIPTION
This is raising a warning that it is ignored