### PR TITLE
fix: indent error in snakefile

### DIFF
--- a/{{cookiecutter.project_short_name}}/workflow/Snakefile
+++ b/{{cookiecutter.project_short_name}}/workflow/Snakefile
@@ -46,7 +46,7 @@ rule clean:
          print("Data downloaded to data/ has not been cleaned.")
 
         
- rule sync:
+rule sync:
     params:
         cluster=config["cluster"],
     shell:


### PR DESCRIPTION
Workflow does not execute due to indent error. Fixed in this PR.